### PR TITLE
allow custom validation errors

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -62,6 +62,9 @@ Request ID
 
 Extracts header "X-Request-ID" and keeps it in context.
 You can pass `force_new_uuid=True` to enforce the creation of a new UUID.
+It validates the header value is a valid UUID, and raises a ValueError('Wrong uuid').
+Pass `validate=False` to disable the check, or `validation_error=your_error`to raise a different error.
+
 
 **********
 User Agent

--- a/starlette_context/plugins/base.py
+++ b/starlette_context/plugins/base.py
@@ -59,7 +59,6 @@ class PluginUUIDBase(Plugin):
         self.force_new_uuid = force_new_uuid
         self.version = version
         self.validate = validate
-        
         self.validation_error = validation_error or ValueError("Wrong uuid")
 
     def validate_uuid(self, uuid_to_validate: str) -> None:

--- a/starlette_context/plugins/base.py
+++ b/starlette_context/plugins/base.py
@@ -52,7 +52,7 @@ class PluginUUIDBase(Plugin):
         force_new_uuid: bool = False,
         version: int = 4,
         validate: bool = True,
-        validation_error = None
+        validation_error: Exception = None
     ):
         if version not in self.uuid_functions_mapper:
             raise TypeError(f"UUID version {version} is not supported.")

--- a/starlette_context/plugins/base.py
+++ b/starlette_context/plugins/base.py
@@ -52,18 +52,21 @@ class PluginUUIDBase(Plugin):
         force_new_uuid: bool = False,
         version: int = 4,
         validate: bool = True,
+        validation_error = None
     ):
         if version not in self.uuid_functions_mapper:
             raise TypeError(f"UUID version {version} is not supported.")
         self.force_new_uuid = force_new_uuid
         self.version = version
         self.validate = validate
+        
+        self.validation_error = validation_error or ValueError("Wrong uuid")
 
     def validate_uuid(self, uuid_to_validate: str) -> None:
         try:
             uuid.UUID(uuid_to_validate, version=self.version)
         except Exception as e:
-            raise ValueError("Wrong uuid") from e
+            raise self.validation_error from e
 
     def get_new_uuid(self) -> str:
         func = self.uuid_functions_mapper[self.version]

--- a/tests/test_plugins/test_request_id.py
+++ b/tests/test_plugins/test_request_id.py
@@ -48,8 +48,7 @@ def test_invalid_request_id_raises_exception_on_uuid_validation():
 
 
 def test_invalid_request_id_with_custom_error():
-    error_message = 'X-Request-ID header is not a valid UUID'
-    
+    error_message = "X-Request-ID header is not a valid UUID"
     middleware = [
         Middleware(
             ContextMiddleware,
@@ -64,8 +63,7 @@ def test_invalid_request_id_with_custom_error():
         "/", headers={HeaderKeys.request_id: "invalid_uuid"}
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()['detail'] == error_message
-    assert HeaderKeys.request_id not in response.headers
+    assert response.json()["detail"] == error_message
 
 
 def test_missing_header_will_assign_one():

--- a/tests/test_plugins/test_request_id.py
+++ b/tests/test_plugins/test_request_id.py
@@ -49,15 +49,13 @@ def test_invalid_request_id_raises_exception_on_uuid_validation():
 
 def test_invalid_request_id_with_custom_error():
     error_message = "X-Request-ID header is not a valid UUID"
+    error = HTTPException(400, detail=error_message)
     middleware = [
-        Middleware(
-            ContextMiddleware,
-            plugins=(plugins.RequestIdPlugin(
-                validation_error=HTTPException(400, detail=error_message)),),
-        )
+        Middleware(ContextMiddleware, plugins=(
+            plugins.RequestIdPlugin(validation_error=error),),)
     ]
     app = Starlette(middleware=middleware)
-    client = TestClient(app)
+    client = TestClient(app, raise_server_exceptions=False)
 
     response = client.get(
         "/", headers={HeaderKeys.request_id: "invalid_uuid"}

--- a/tests/test_plugins/test_request_id.py
+++ b/tests/test_plugins/test_request_id.py
@@ -51,15 +51,15 @@ def test_invalid_request_id_with_custom_error():
     error_message = "X-Request-ID header is not a valid UUID"
     error = HTTPException(400, detail=error_message)
     middleware = [
-        Middleware(ContextMiddleware, plugins=(
-            plugins.RequestIdPlugin(validation_error=error),),)
+        Middleware(
+            ContextMiddleware,
+            plugins=(plugins.RequestIdPlugin(validation_error=error),),
+        )
     ]
     app = Starlette(middleware=middleware)
-    client = TestClient(app, raise_server_exceptions=False)
+    client = TestClient(app)
 
-    response = client.get(
-        "/", headers={HeaderKeys.request_id: "invalid_uuid"}
-    )
+    response = client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["detail"] == error_message
 


### PR DESCRIPTION
sorry the git diff shows the whole file changed.
actual changes: PluginUUIDBase init takes a validation_error argument, defaulting to None. it is used while raising validation errors instead of the ValueError. the ValueError is still kept as default if none sent.
This allows user code to change the error to a 400 error, which I feel is more appropriate than a 500. 
tested in `test_invalid_request_id_with_custom_error`.
