### PR TITLE
Allow custom validation response

### DIFF
--- a/starlette_context/ctx.py
+++ b/starlette_context/ctx.py
@@ -3,7 +3,10 @@ from contextvars import copy_context
 from typing import Any
 
 from starlette_context import _request_scope_context_storage
-from starlette_context.errors import ContextDoesNotExistError
+from starlette_context.errors import (
+    ContextDoesNotExistError,
+    ConfigurationError,
+)
 
 
 class _Context(UserDict):
@@ -17,7 +20,7 @@ class _Context(UserDict):
     def __init__(self, *args: Any, **kwargs: Any):  # noqa
         # not calling super on purpose
         if args or kwargs:
-            raise AttributeError("Can't instantiate with attributes")
+            raise ConfigurationError("Can't instantiate with attributes")
 
     @property
     def data(self) -> dict:  # type: ignore

--- a/starlette_context/errors.py
+++ b/starlette_context/errors.py
@@ -1,4 +1,12 @@
-class ContextDoesNotExistError(RuntimeError):
+from typing import Optional
+from starlette.responses import Response
+
+
+class StarletteContextError(BaseException):
+    pass
+
+
+class ContextDoesNotExistError(RuntimeError, StarletteContextError):
     def __init__(self):
         self.message = (
             "You didn't use the required middleware or "
@@ -6,3 +14,23 @@ class ContextDoesNotExistError(RuntimeError):
             "outside of the request-response cycle."
         )
         super().__init__(self.message)
+
+
+class ConfigurationError(StarletteContextError):
+    pass
+
+
+class MiddleWareValidationError(StarletteContextError):
+    def __init__(
+        self, *args, error_response: Optional[Response] = None
+    ) -> None:
+        super().__init__(*args)
+        self.error_response = error_response
+
+
+class WrongUUIDError(MiddleWareValidationError):
+    pass
+
+
+class DateFormatError(MiddleWareValidationError):
+    pass

--- a/starlette_context/middleware/raw_middleware.py
+++ b/starlette_context/middleware/raw_middleware.py
@@ -14,13 +14,13 @@ class RawContextMiddleware:
         self,
         app: ASGIApp,
         plugins: Optional[Sequence[Plugin]] = None,
-        defaut_error_response: Response = Response(status_code=400)
+        defaut_error_response: Response = Response(status_code=400),
     ) -> None:
         self.app = app
         for plugin in plugins or ():
             if not isinstance(plugin, Plugin):
                 raise TypeError(f"Plugin {plugin} is not a valid instance")
-        
+
         self.plugins = plugins or ()
         self.error_response = defaut_error_response
 
@@ -61,7 +61,7 @@ class RawContextMiddleware:
             await send(message)
 
         request = self.get_request_object(scope, receive, send)
-        
+
         try:
             context = await self.set_context(request)
         except ValueError as e:
@@ -71,19 +71,19 @@ class RawContextMiddleware:
                 error_response = self.error_response
 
             message_head = {
-                'type': 'http.response.start',
-                'status': error_response.status_code,
-                'headers': error_response.raw_headers,
+                "type": "http.response.start",
+                "status": error_response.status_code,
+                "headers": error_response.raw_headers,
             }
             await send(message_head)
 
             message_body = {
-                'type': 'http.response.body',
-                'body': error_response.body
+                "type": "http.response.body",
+                "body": error_response.body,
             }
             await send(message_body)
             return
-        
+
         token: Token = _request_scope_context_storage.set(context)
 
         try:

--- a/starlette_context/plugins/base.py
+++ b/starlette_context/plugins/base.py
@@ -55,7 +55,7 @@ class PluginUUIDBase(Plugin):
         force_new_uuid: bool = False,
         version: int = 4,
         validate: bool = True,
-        error_response: Optional[Response] = None
+        error_response: Optional[Response] = None,
     ):
         if version not in self.uuid_functions_mapper:
             raise TypeError(f"UUID version {version} is not supported.")

--- a/starlette_context/plugins/base.py
+++ b/starlette_context/plugins/base.py
@@ -8,6 +8,7 @@ from starlette.responses import Response
 from starlette.types import Message
 
 from starlette_context import context
+from starlette_context.errors import WrongUUIDError, ConfigurationError
 
 __all__ = ["Plugin", "PluginUUIDBase"]
 
@@ -58,7 +59,9 @@ class PluginUUIDBase(Plugin):
         error_response: Optional[Response] = None,
     ):
         if version not in self.uuid_functions_mapper:
-            raise TypeError(f"UUID version {version} is not supported.")
+            raise ConfigurationError(
+                f"UUID version {version} is not supported."
+            )
         self.force_new_uuid = force_new_uuid
         self.version = version
         self.validate = validate
@@ -68,7 +71,9 @@ class PluginUUIDBase(Plugin):
         try:
             uuid.UUID(uuid_to_validate, version=self.version)
         except Exception as e:
-            raise ValueError(self.error_response or "Wrong uuid") from e
+            raise WrongUUIDError(
+                "Wrong uuid", error_response=self.error_response
+            ) from e
 
     def get_new_uuid(self) -> str:
         func = self.uuid_functions_mapper[self.version]

--- a/starlette_context/plugins/base.py
+++ b/starlette_context/plugins/base.py
@@ -55,18 +55,20 @@ class PluginUUIDBase(Plugin):
         force_new_uuid: bool = False,
         version: int = 4,
         validate: bool = True,
+        error_response: Optional[Response] = None
     ):
         if version not in self.uuid_functions_mapper:
             raise TypeError(f"UUID version {version} is not supported.")
         self.force_new_uuid = force_new_uuid
         self.version = version
         self.validate = validate
+        self.error_response = error_response
 
     def validate_uuid(self, uuid_to_validate: str) -> None:
         try:
             uuid.UUID(uuid_to_validate, version=self.version)
         except Exception as e:
-            raise ValueError("Wrong uuid") from e
+            raise ValueError(self.error_response or "Wrong uuid") from e
 
     def get_new_uuid(self) -> str:
         func = self.uuid_functions_mapper[self.version]

--- a/starlette_context/plugins/date_header.py
+++ b/starlette_context/plugins/date_header.py
@@ -2,13 +2,23 @@ import datetime
 from typing import Optional, Union
 
 from starlette.requests import HTTPConnection, Request
+from starlette.responses import Response
 
 from starlette_context.header_keys import HeaderKeys
 from starlette_context.plugins.base import Plugin
+from starlette_context.errors import DateFormatError
 
 
 class DateHeaderPlugin(Plugin):
     key = HeaderKeys.date
+
+    def __init__(
+        self,
+        *args,
+        error_response: Optional[Response] = Response(status_code=400),
+    ):
+        super().__init__(*args)
+        self.error_response = error_response
 
     @staticmethod
     def rfc1123_to_dt(s: str) -> datetime.datetime:
@@ -32,10 +42,15 @@ class DateHeaderPlugin(Plugin):
             dt_str, dt_data = rfc1123[:25], rfc1123[25:]
 
             if dt_data.strip() not in ("", "GMT"):  # empty str assumes ok
-                raise ValueError(
-                    "Date header in wrong format, has to match rfc1123."
+                raise DateFormatError(
+                    "Date header in wrong format, has to match rfc1123.",
+                    error_response=self.error_response,
                 )
 
-            value = self.rfc1123_to_dt(dt_str.strip())
-
+            try:
+                value = self.rfc1123_to_dt(dt_str.strip())
+            except ValueError as e:
+                raise DateFormatError(
+                    str(e), error_response=self.error_response
+                )
         return value

--- a/tests/test_context/test_context_no_middleware.py
+++ b/tests/test_context/test_context_no_middleware.py
@@ -5,6 +5,7 @@ from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
 from starlette_context import context
+from starlette_context.errors import ContextDoesNotExistError
 
 app = Starlette()
 client = TestClient(app)
@@ -16,5 +17,5 @@ async def index(request: Request):
 
 
 def test_no_middleware():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ContextDoesNotExistError):
         client.get("/")

--- a/tests/test_context/test_mocked_context_object.py
+++ b/tests/test_context/test_mocked_context_object.py
@@ -1,6 +1,7 @@
 import pytest
 
 from starlette_context.ctx import _Context
+from starlette_context.errors import ConfigurationError
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -17,7 +18,7 @@ def mocked_context(monkeypatch, ctx_store) -> _Context:
 
 
 def test_ctx_init():
-    with pytest.raises(AttributeError):
+    with pytest.raises(ConfigurationError):
         _Context(test=True)
 
 

--- a/tests/test_plugins/test_correlation_id.py
+++ b/tests/test_plugins/test_correlation_id.py
@@ -35,16 +35,11 @@ def test_valid_request_returns_proper_response():
     )
 
 
-def test_invalid_correlation_id_raises_exception_on_uuid_validation():
-    with pytest.raises(ValueError):
-        client.get("/", headers={HeaderKeys.correlation_id: "invalid_uuid"})
-
-    allow_500_client = TestClient(app, raise_server_exceptions=False)
-    response = allow_500_client.get(
+def test_invalid_correlation_id_returns_a_bad_request():
+    response = client.get(
         "/", headers={HeaderKeys.correlation_id: "invalid_uuid"}
     )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert HeaderKeys.correlation_id not in response.headers
 
 

--- a/tests/test_plugins/test_correlation_id.py
+++ b/tests/test_plugins/test_correlation_id.py
@@ -7,6 +7,7 @@ from starlette.responses import Response
 from starlette.testclient import TestClient
 
 from starlette_context import plugins
+from starlette_context.errors import ConfigurationError
 from starlette_context.header_keys import HeaderKeys
 from starlette_context.middleware import ContextMiddleware
 from tests.conftest import dummy_correlation_id
@@ -73,7 +74,7 @@ def test_force_new_uuid():
 
 
 def test_unsupported_uuid():
-    with pytest.raises(TypeError):
+    with pytest.raises(ConfigurationError):
         plugins.CorrelationIdPlugin(
             force_new_uuid=True, validate=False, version=1
         )

--- a/tests/test_plugins/test_date.py
+++ b/tests/test_plugins/test_date.py
@@ -52,21 +52,15 @@ def test_rfc1123_parsing_method():
 
 
 def test_invalid_date_header_raises_exception():
-    with pytest.raises(ValueError):
-        client.get("/", headers={HeaderKeys.date: "invalid_date"})
+    response1 = client.get("/", headers={HeaderKeys.date: "invalid_date"})
+    assert response1.status_code == status.HTTP_400_BAD_REQUEST
+    assert HeaderKeys.date not in response1.headers
 
-    with pytest.raises(ValueError):
-        client.get(
-            "/", headers={HeaderKeys.date: "Wed, 01 Jan 2020 04:27:12 invalid"}
-        )
-
-    allow_500_client = TestClient(app, raise_server_exceptions=False)
-    response = allow_500_client.get(
-        "/", headers={HeaderKeys.date: "invalid_date"}
+    response2 = client.get(
+        "/", headers={HeaderKeys.date: "Wed, 01 Jan 2020 04:27:12 invalid"}
     )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert HeaderKeys.date not in response.headers
+    assert response2.status_code == status.HTTP_400_BAD_REQUEST
+    assert HeaderKeys.date not in response2.headers
 
 
 def test_missing_header_date():

--- a/tests/test_plugins/test_error_responses.py
+++ b/tests/test_plugins/test_error_responses.py
@@ -1,0 +1,63 @@
+from typing import Type
+
+from starlette import status
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.responses import JSONResponse, Response
+from starlette.testclient import TestClient
+
+from starlette_context import plugins
+from starlette_context.header_keys import HeaderKeys
+from starlette_context.middleware import (
+    ContextMiddleware,
+    RawContextMiddleware,
+)
+
+
+def gen_middleware_config(
+    middleware_class: Type, response: Response
+) -> TestClient:
+    middleware = [
+        Middleware(
+            middleware_class,
+            plugins=(plugins.RequestIdPlugin(error_response=response),),
+        )
+    ]
+    app = Starlette(middleware=middleware)
+    client = TestClient(app)
+    return client
+
+
+def test_invalid_request_id_returns_specified_response_raw_middleware():
+    content = {"Error": "Invalid X-Request-ID"}
+    response = JSONResponse(
+        content=content, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+    )
+    client = gen_middleware_config(RawContextMiddleware, response)
+
+    response = client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert HeaderKeys.request_id not in response.headers
+    body = response.json()
+    assert body == content
+
+
+def test_invalid_request_id_returns_specified_response_context_middleware():
+    content = {"Error": "Invalid X-Request-ID"}
+    response = JSONResponse(
+        content=content, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY
+    )
+    client = gen_middleware_config(ContextMiddleware, response)
+    response = client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert HeaderKeys.request_id not in response.headers
+    body = response.json()
+    assert body == content
+
+
+def test_invalid_request_id_unspecified_response_raw_middleware():
+    client = gen_middleware_config(RawContextMiddleware, None)
+    response = client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert HeaderKeys.request_id not in response.headers
+    assert response.content == b""

--- a/tests/test_plugins/test_request_id.py
+++ b/tests/test_plugins/test_request_id.py
@@ -1,4 +1,3 @@
-import pytest
 from starlette import status
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -33,16 +32,9 @@ def test_valid_request_returns_proper_response():
     assert response.headers.get(HeaderKeys.request_id) == dummy_request_id
 
 
-def test_invalid_request_id_raises_exception_on_uuid_validation():
-    with pytest.raises(ValueError):
-        client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
-
-    allow_500_client = TestClient(app, raise_server_exceptions=False)
-    response = allow_500_client.get(
-        "/", headers={HeaderKeys.request_id: "invalid_uuid"}
-    )
-
-    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+def test_invalid_request_id_returns_a_bad_request():
+    response = client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert HeaderKeys.request_id not in response.headers
 
 

--- a/tests/test_plugins/test_wrong_plugin.py
+++ b/tests/test_plugins/test_wrong_plugin.py
@@ -1,3 +1,4 @@
+from starlette_context.errors import ConfigurationError
 import pytest
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -13,14 +14,14 @@ class NotAPlugin:
 
 
 def test_context_middleware_wrong_plugin():
-    with pytest.raises(TypeError):
+    with pytest.raises(ConfigurationError):
         Starlette(
             middleware=[Middleware(ContextMiddleware, plugins=(NotAPlugin(),))]
         )
 
 
 def test_raw_middleware_wrong_plugin():
-    with pytest.raises(TypeError):
+    with pytest.raises(ConfigurationError):
         Starlette(
             middleware=[
                 Middleware(RawContextMiddleware, plugins=(NotAPlugin(),))


### PR DESCRIPTION
This PR fixes 2 issues:
- A user sending invalid data in a UUID-based plugin should not result in a server error, but a client error with a 400 status code.
- Middlewares in Starlette should not raise Exceptions, they should abort the request cycle and send a response instead.

The exact error is customizable from user code, but provides a default 400 response with empty body.
Implemented on both ContextMiddleware and RawContextMiddleware.
