### PR TITLE
wip: drop error_response, add error detail and support for serialization

### DIFF
--- a/starlette_context/plugins/date_header.py
+++ b/starlette_context/plugins/date_header.py
@@ -2,7 +2,6 @@ import datetime
 from typing import Optional, Union
 
 from starlette.requests import HTTPConnection, Request
-from starlette.responses import Response
 
 from starlette_context.header_keys import HeaderKeys
 from starlette_context.plugins.base import Plugin
@@ -11,14 +10,6 @@ from starlette_context.errors import DateFormatError
 
 class DateHeaderPlugin(Plugin):
     key = HeaderKeys.date
-
-    def __init__(
-        self,
-        *args,
-        error_response: Optional[Response] = Response(status_code=400),
-    ):
-        super().__init__(*args)
-        self.error_response = error_response
 
     @staticmethod
     def rfc1123_to_dt(s: str) -> datetime.datetime:
@@ -42,15 +33,10 @@ class DateHeaderPlugin(Plugin):
             dt_str, dt_data = rfc1123[:25], rfc1123[25:]
 
             if dt_data.strip() not in ("", "GMT"):  # empty str assumes ok
-                raise DateFormatError(
-                    "Date header in wrong format, has to match rfc1123.",
-                    error_response=self.error_response,
-                )
+                raise DateFormatError
 
             try:
                 value = self.rfc1123_to_dt(dt_str.strip())
             except ValueError as e:
-                raise DateFormatError(
-                    str(e), error_response=self.error_response
-                )
+                raise DateFormatError(detail=str(e))
         return value

--- a/tests/test_plugins/test_correlation_id.py
+++ b/tests/test_plugins/test_correlation_id.py
@@ -40,7 +40,7 @@ def test_invalid_correlation_id_returns_a_bad_request():
     response = client.get(
         "/", headers={HeaderKeys.correlation_id: "invalid_uuid"}
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert HeaderKeys.correlation_id not in response.headers
 
 

--- a/tests/test_plugins/test_date.py
+++ b/tests/test_plugins/test_date.py
@@ -53,13 +53,13 @@ def test_rfc1123_parsing_method():
 
 def test_invalid_date_header_raises_exception():
     response1 = client.get("/", headers={HeaderKeys.date: "invalid_date"})
-    assert response1.status_code == status.HTTP_400_BAD_REQUEST
+    assert response1.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert HeaderKeys.date not in response1.headers
 
     response2 = client.get(
         "/", headers={HeaderKeys.date: "Wed, 01 Jan 2020 04:27:12 invalid"}
     )
-    assert response2.status_code == status.HTTP_400_BAD_REQUEST
+    assert response2.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert HeaderKeys.date not in response2.headers
 
 

--- a/tests/test_plugins/test_request_id.py
+++ b/tests/test_plugins/test_request_id.py
@@ -34,7 +34,7 @@ def test_valid_request_returns_proper_response():
 
 def test_invalid_request_id_returns_a_bad_request():
     response = client.get("/", headers={HeaderKeys.request_id: "invalid_uuid"})
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert HeaderKeys.request_id not in response.headers
 
 


### PR DESCRIPTION
Closes https://github.com/tomwojcik/starlette-context/issues/58

- starlette errors are returned as PlainTextResponse, so lets do that https://github.com/encode/starlette/blob/389cbfcaa529686bfd4cfab0bfa338a531a389c8/starlette/exceptions.py#L103
- add support for server / client errors. Server errors always return 500. Client errors 4xx with a meaningful message.
- client errors will now return the error message in the response
- drop support for `error_response`. You said
[> sending a response object through the exception is weird, but I can't see any other way to make it work nicely with plugins.](https://github.com/tomwojcik/starlette-context/pull/30#issuecomment-855216483)
but I believe changes from this implementation will do the trick. 

todo:
- docs