### PR TITLE
`starlette_context` context manager

### DIFF
--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -24,8 +24,7 @@ Following operations work as expected
  - ``context.items()``
  - ``context["key"] = "value"``
 
-
 To make it available during the request-response cycle, it needs to be instantiated in the Starlette app with one of the middlewares,
-or the ``starlette_context`` context manager, which can be useful in FastAPI Depends or unit tests requiring an available context.
+or the ``request_cycle_context`` context manager, which can be useful in FastAPI Depends or unit tests requiring an available context.
 The middleware approach offer extended capability the form of plugins to process and extend the request, but needs to redefine the error response in case those plugins raise an Exception.
 The context manager approach is more barebone, which likely will lead you to implement the initial context population yourself.

--- a/docs/source/context.rst
+++ b/docs/source/context.rst
@@ -24,4 +24,8 @@ Following operations work as expected
  - ``context.items()``
  - ``context["key"] = "value"``
 
-It will be available during the request-response cycle only if instantiated in the Starlette app with one of the middlewares.
+
+To make it available during the request-response cycle, it needs to be instantiated in the Starlette app with one of the middlewares,
+or the ``starlette_context`` context manager, which can be useful in FastAPI Depends or unit tests requiring an available context.
+The middleware approach offer extended capability the form of plugins to process and extend the request, but needs to redefine the error response in case those plugins raise an Exception.
+The context manager approach is more barebone, which likely will lead you to implement the initial context population yourself.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,9 @@ starlette-context
    middleware
    plugins
    errors
+   testing
    example
+   fastapi
    contributing
    license
    changelog

--- a/starlette_context/__init__.py
+++ b/starlette_context/__init__.py
@@ -11,7 +11,9 @@ _request_scope_context_storage: ContextVar[Dict[Any, Any]] = ContextVar(
 
 
 @contextmanager
-def starlette_context(initial_data: Optional[dict] = None) -> Iterator[None]:
+def request_cycle_context(
+    initial_data: Optional[dict] = None,
+) -> Iterator[None]:
     """
     Creates and resets a starlette context context.
 
@@ -29,4 +31,4 @@ def starlette_context(initial_data: Optional[dict] = None) -> Iterator[None]:
 
 from starlette_context.ctx import context  # noqa: E402
 
-__all__ = ["context", "starlette_context"]
+__all__ = ["context", "request_cycle_context"]

--- a/starlette_context/middleware/__init__.py
+++ b/starlette_context/middleware/__init__.py
@@ -1,2 +1,7 @@
 from .context_middleware import ContextMiddleware
 from .raw_middleware import RawContextMiddleware
+
+__all__ = [
+    "ContextMiddleware",
+    "RawContextMiddleware",
+]

--- a/starlette_context/middleware/context_middleware.py
+++ b/starlette_context/middleware/context_middleware.py
@@ -7,7 +7,7 @@ from starlette.middleware.base import (
 from starlette.requests import Request
 from starlette.responses import Response
 
-from starlette_context import starlette_context
+from starlette_context import request_cycle_context
 from starlette_context.plugins import Plugin
 from starlette_context.errors import (
     ConfigurationError,
@@ -62,7 +62,7 @@ class ContextMiddleware(BaseHTTPMiddleware):
             return error_response
 
         # create request-scoped context
-        with starlette_context(context):
+        with request_cycle_context(context):
             # process rest of response stack
             response = await call_next(request)
             # gets back to middleware, process response with plugins

--- a/starlette_context/middleware/raw_middleware.py
+++ b/starlette_context/middleware/raw_middleware.py
@@ -4,7 +4,7 @@ from starlette.requests import HTTPConnection, Request
 from starlette.responses import Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from starlette_context import starlette_context
+from starlette_context import request_cycle_context
 from starlette_context.plugins import Plugin
 from starlette_context.errors import (
     ConfigurationError,
@@ -89,5 +89,5 @@ class RawContextMiddleware:
             error_response = e.error_response or self.error_response
             return await self.send_response(error_response, send)
 
-        with starlette_context(context):
+        with request_cycle_context(context):
             await self.app(scope, receive, send_wrapper)

--- a/tests/test_context/test_manager.py
+++ b/tests/test_context/test_manager.py
@@ -9,7 +9,7 @@ plugins, and alleviating the Starlette architecture making Middlewares out of
 the scope of the regular exception handler.
 """
 import pytest
-from starlette_context import starlette_context, context
+from starlette_context import request_cycle_context, context
 from starlette_context.errors import ContextDoesNotExistError
 
 
@@ -21,7 +21,7 @@ def test_context_created_within_manager():
         context.get("test")
     assert not context.exists()
 
-    with starlette_context(original_data):
+    with request_cycle_context(original_data):
         # context available here
         assert context["test"] == "success"
 
@@ -34,7 +34,7 @@ def test_context_created_within_manager():
 def test_can_add_within():
     original_data = {"test": "success"}
 
-    with starlette_context(original_data):
+    with request_cycle_context(original_data):
         # context available here
         context["extra"] = "more"
 
@@ -44,5 +44,5 @@ def test_can_add_within():
 
 
 def test_no_initial_data():
-    with starlette_context():
+    with request_cycle_context():
         assert context.exists()

--- a/tests/test_context/test_manager.py
+++ b/tests/test_context/test_manager.py
@@ -1,0 +1,48 @@
+"""
+Tests the context manager without using the middlewares. This feature makes it
+much easier for users to also test the usage of context in a unit test
+environnment, allowing to create the assumed/mocked environnment directly in a
+similar way to having a middleware upstream processing a request.
+
+On FastAPI apps, this also allows usage as part of a Depends system, out of
+plugins, and alleviating the Starlette architecture making Middlewares out of
+the scope of the regular exception handler.
+"""
+import pytest
+from starlette_context import starlette_context, context
+from starlette_context.errors import ContextDoesNotExistError
+
+
+def test_context_created_within_manager():
+    original_data = {"test": "success"}
+
+    # no context yet
+    with pytest.raises(ContextDoesNotExistError):
+        context.get("test")
+    assert not context.exists()
+
+    with starlette_context(original_data):
+        # context available here
+        assert context["test"] == "success"
+
+    # no context anymore
+    with pytest.raises(ContextDoesNotExistError):
+        context.get("test")
+    assert not context.exists()
+
+
+def test_can_add_within():
+    original_data = {"test": "success"}
+
+    with starlette_context(original_data):
+        # context available here
+        context["extra"] = "more"
+
+        assert context.get("extra") == "more"
+        assert context.get("test") == "success"
+        assert context.get("other") is None
+
+
+def test_no_initial_data():
+    with starlette_context():
+        assert context.exists()


### PR DESCRIPTION
This creates and exposes a context manager that instantiates and resets the Token.

This isn't much actual code, it may look like it only slightly improves the code reuse of the token initialization/reset code,
but exposing it while abstracting the internal details allows 2 more important use cases:
- within unit tests, creating a mock environment to test a portion using the `context` out of a request-response cycle (helping for #46).
- leveraging FastAPI framework Depends() to allow required/optional headers to be visibly documented, plus use the full scope of FastAPI features (such as easy access to the request's body within a Depends system, (as #50 shown might be a use case).

This also introduces the first explicit support of FastAPI, which, while limited, may attract more attention to the library.
