### PR TITLE
Enforce opaque Context object repr

### DIFF
--- a/starlette_context/ctx.py
+++ b/starlette_context/ctx.py
@@ -43,5 +43,10 @@ class _Context(UserDict):
 
         return copy.copy(self.data)
 
+    def __repr__(self) -> str:
+        # Opaque type to avoid default implementation
+        # that could try to look into data while out of request cycle
+        return f"<{__name__}.{self.__class__.__name__} object>"
+
 
 context = _Context()

--- a/tests/test_context/test_mocked_context_object.py
+++ b/tests/test_context/test_mocked_context_object.py
@@ -27,7 +27,11 @@ def test_ctx_eq(mocked_context: _Context, ctx_store: dict):
 
 
 def test_ctx_repr(mocked_context: _Context, ctx_store: dict):
-    assert str(ctx_store) == mocked_context.__repr__()
+    assert repr(mocked_context) == "<starlette_context.ctx._Context object>"
+
+
+def test_ctx_data_str(mocked_context: _Context, ctx_store: dict):
+    assert str(mocked_context.data) == str(ctx_store)
 
 
 def test_ctx_len(mocked_context: _Context, ctx_store: dict):


### PR DESCRIPTION
As mentioned in #65 , the default `__repr__` trying to access inner data can be problematic in legitimate out-of-request-cycle situations, such as module -wide introspection and documentation generation.