### PR TITLE
Docs: request_cycle_context

### DIFF
--- a/docs/source/fastapi.rst
+++ b/docs/source/fastapi.rst
@@ -1,0 +1,44 @@
+==================
+Usage with FastAPI
+==================
+
+FastAPI being built on top of Starlette, ``starlette_context`` is compatible with the FastAPI framework.
+
+It can be used in the same way, with the same middlewares as a regular Starlette application.
+
+FastAPI however offers another interesting feature with its Depends system and auto-generated OpenAPI documentation.
+Using a middleware escapes this documentation generation, so if your app requires some specific headers from a middleware,
+those would not appear in your API documentation, which is quite infortunate.
+
+FastAPI ``Depends`` offers a way to solve this issue.
+Instead of using middlewares, you can use a common Dependency, taking the data from the request it needs there, all while documenting it.
+A FastAPI Depends with a ``yield`` can have a similar role to a middleware to manage the context, allowing code to be executed before as well as after the request.
+You can find more information regarding this usage on the `FastAPI documentation <https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/>`_
+
+The same ``request_cycle_context`` presented in :ref:`Testing` can be used to create this Depends
+As an upside, errors raised there would folow the regular error handling.
+As a downside, it cannot use the plugins system for middlewares, so the data from headers or else that you need must be implemented yourself, respecting FastAPI usage.
+
+.. code-block:: python
+
+    from starlette_context import context, request_cycle_context
+    from fastapi import FastAPI, Depends, HTTPException, Header
+
+
+    async def my_context_dependency(x_client_id = Header(...)):
+        # When used a Depends(), this fucntion get the `X-Client_ID` header,
+        # which will be documented as a required header by FastAPI.
+        # use `x_client_id: str = Header(None)` for an optional header.
+
+        data = {"x_client_id": x_client_id}
+        with request_cycle_context(data):
+            # yield allows it to pass along to the rest of the request
+            yield
+
+    # use it as Depends across the whole FastAPI app
+    app = FastAPI(dependencies=[Depends(my_context_dependency)])
+
+    @app.get("/")
+    async def hello():
+        client = context["x_client_id"]
+        return f"hello {client}"

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -1,0 +1,26 @@
+==========
+Testing
+==========
+
+
+As part of your application logic flow, you will come to functions that expect the context to be available with specific data at runtime.
+
+Testing such functions while very much valid during usual server runtime, may be trickier in a testing environnment, as it is not during an actual request-response cycle.
+While it can be done in a full-blown integration test, if you want to test the functionality of your function extensively while keeping it to a limited scope during unit test,
+you can use the ``request_cycle_context`` context manager.
+
+.. code-block:: python
+
+    import logging
+    from starlette_context import context, request_cycle_context
+
+    # original function assuming a context available
+    def original_function():
+        client_id = context["x-client-id"]
+        return client_id
+
+    # test
+    def test_my_function():
+        assumed_context = {"x-client-id": "unit testing!"}
+        with request_cycle_context(assumed_context):
+            assert original_function() == "unit testing!"


### PR DESCRIPTION
After the rename, i realized I forgot to update some parts of the docs I had written
and then it seems they weren't even part of the original PR, I guess I didn't even commit them in the first place.
or were they lost in the rebase? they're referenced in the original PR's `index.rst` already, I'm not sure the docs could build without those.
anyway, here are some extra docs about usage of the context manager.