### PR TITLE
yield without try-except

### DIFF
--- a/starlette_context/__init__.py
+++ b/starlette_context/__init__.py
@@ -23,10 +23,8 @@ def request_cycle_context(
     if initial_data is None:
         initial_data = {}
     token: Token = _request_scope_context_storage.set(initial_data.copy())
-    try:
-        yield
-    finally:
-        _request_scope_context_storage.reset(token)
+    yield
+    _request_scope_context_storage.reset(token)
 
 
 from starlette_context.ctx import context  # noqa: E402


### PR DESCRIPTION
Fix for #74 : yielding within a try-except block executes the exit code before a FastAPI error handler is executed, making the context unusable in such situations.
It looks like it didn't need to be in this block, as it is already within a context manager by itself.
Putting this up as I said I'd double check the fix, and haven't actually checked as thoroughly as I wanted but the idea is simple, it shouldn't have taken that long to fix.
https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-with-yield/
