### PR TITLE
Simple test case to check if header is available in failed request response, if handled

### DIFF
--- a/tests/test_context/test_context_on_unhandled_exception.py
+++ b/tests/test_context/test_context_on_unhandled_exception.py
@@ -5,7 +5,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.testclient import TestClient
 
-from starlette_context import middleware, plugins
+from starlette_context import middleware, plugins, context
 from starlette_context.header_keys import HeaderKeys
 
 app = Starlette(
@@ -17,9 +17,23 @@ app = Starlette(
 )
 
 
+class CustomExc(Exception):
+    pass
+
+
 @app.route("/exc")
 async def exc(request: Request):
     raise Exception
+
+
+@app.route("/handled")
+async def handled(request: Request):
+    raise CustomExc
+
+
+@app.exception_handler(CustomExc)
+def f(request: Request):
+    return Response(status_code=400, headers=context.data)
 
 
 @app.route("/")
@@ -38,3 +52,7 @@ def test_context_persistence():
     resp = client.get("/exc")
     assert resp.status_code == 500
     assert HeaderKeys.request_id.lower() not in resp.headers
+
+    resp = client.get("/handled")
+    assert resp.status_code == 400
+    assert HeaderKeys.request_id.lower() in resp.headers


### PR DESCRIPTION
CC @hhamana 

When pushing changes I was sure this test is passing... Anyway, simple repro is needed to prove in tests that the context can be available in the exc handler. For some reason it's not possible to reach it in unit test though.