### PR TITLE
Issue 90 exception inheritance

### DIFF
--- a/starlette_context/errors.py
+++ b/starlette_context/errors.py
@@ -2,7 +2,7 @@ from typing import Optional
 from starlette.responses import Response
 
 
-class StarletteContextError(BaseException):
+class StarletteContextError(Exception):
     pass
 
 

--- a/tests/test_plugins/test_exceptions.py
+++ b/tests/test_plugins/test_exceptions.py
@@ -1,0 +1,7 @@
+from starlette_context.errors import StarletteContextError
+
+
+def test_context_exception_is_catchable():
+    """Ensure base context error inherits from Exception so that a normal
+    try/except will catch it (test exists to prevent future regression)"""
+    assert issubclass(StarletteContextError, Exception)


### PR DESCRIPTION
Fixes issue described in #90 

Things like the basic FastAPI exception handler middleware were allowing exceptions from Context to fall through because they were inheriting from BaseException.