### PR TITLE
HeaderKeys behavior is not consistent across python versions.

### DIFF
--- a/starlette_context/header_keys.py
+++ b/starlette_context/header_keys.py
@@ -1,7 +1,15 @@
-from enum import Enum
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
 
 
-class HeaderKeys(str, Enum):
+class HeaderKeys(StrEnum):
     api_key = "X-API-Key"
     correlation_id = "X-Correlation-ID"
     request_id = "X-Request-ID"


### PR DESCRIPTION
In [python 3.11](https://docs.python.org/3/whatsnew/3.11.html#enum), the behavior of `Enum.format()` was changed:

> Changed [Enum.__format__()](https://docs.python.org/3/library/enum.html#enum.Enum.__format__) (the default for [format()](https://docs.python.org/3/library/functions.html#format), [str.format()](https://docs.python.org/3/library/stdtypes.html#str.format) and [f-string](https://docs.python.org/3/glossary.html#term-f-string)s) to always produce the same result as [Enum.__str__()](https://docs.python.org/3/library/enum.html#enum.Enum.__str__): for enums inheriting from [ReprEnum](https://docs.python.org/3/library/enum.html#enum.ReprEnum) it will be the member’s value; for all other enums it will be the enum and member name (e.g. Color.RED).

This makes the behavior of `HeaderKeys` inconsistent:
```python
# Pre-3.11
assert str(HeaderKeys.api_key) = "X-API-Key"

# Post-3.11
assert str(HeaderKeys.api_key) = "HeaderKeys.api_key"
```

To fix this issue, [`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum) was created and has the same behavior as pre-3.11 `Enum`. We simply conditionally import the right `Enum` class.